### PR TITLE
WP7 hardening: thisismyurl-svg-support (v1.6148.2110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ WordPress blocks SVG uploads by default because SVGs can contain executable code
 - **Safe SVG uploads:** Enables `.svg` and `.svgz` file uploads with allowlist-based server-side sanitization via [enshrined/svg-sanitize](https://github.com/darylldoyle/svg-sanitizer).
 - **Per-role upload allowlist:** Configure which roles can upload SVGs from `Settings > SVG Support`. Backed by a real `upload_svg_files` capability, granted only to roles you check.
 - **MIME validation:** Server-side `finfo_file()` check rejects disguised payloads before sanitization runs.
-- **Sandboxed admin preview:** Media Library previews render in `<iframe sandbox="">`, so script execution and cookie exfil from a pre-sanitization or edge-case payload are denied at the iframe boundary.
 - **Sanitization-failure log:** Last 50 rejection events recorded with filename, reason, user, and IP for incident response.
 - **Bundled sanitizer:** `enshrined/svg-sanitize` is shipped in `vendor/` — no Composer step required to install.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,7 +43,6 @@ authenticated WordPress sessions.
 | **XSS via `<script>`, event handlers, `javascript:` URIs in SVG** | Allowlist sanitization via `enshrined/svg-sanitize` (only known-safe elements/attributes survive). |
 | **Disguised payload (HTML/JS named `.svg`)** | `finfo_file()` MIME check before sanitization rejects content that does not match an SVG MIME family. |
 | **Decompression bomb / billion-laughs in `.svgz`** | 5 MB hard byte ceiling on both compressed and decompressed payloads; `LIBXML_NONET` + entity stripping in the underlying sanitizer. |
-| **Cookie / token exfiltration via Media Library preview** | Admin previews rendered in `<iframe sandbox="" referrerpolicy="no-referrer">` — script execution and credential leakage are denied at the iframe boundary. |
 | **Privilege escalation via untrusted role uploading SVG** | New `upload_svg_files` capability on a per-role allowlist; default grants only `administrator`. |
 | **Silent compromise** | Sanitization-failure log records filename, reason, user, and IP for the most recent 50 events. |
 

--- a/abilities.php
+++ b/abilities.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * WP 7 Abilities API registration for This Is My URL - SVG Support.
+ *
+ * Exposes the plugin's in-memory SVG sanitizer as a discoverable,
+ * REST/AI-invokable READONLY ability: callers pass raw SVG markup (or the ID
+ * of an existing SVG attachment) and receive the sanitized markup plus a
+ * report of what the allowlist sanitizer stripped. Nothing on disk is ever
+ * modified — the attachment path reads a copy into memory and sanitizes that.
+ *
+ * @package TIMU_SVG_Support
+ * @since   1.6148
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return; // Abilities API unavailable (WordPress < 6.9).
+		}
+
+		wp_register_ability(
+			'thisismyurl-svg-support/sanitize-svg',
+			array(
+				'label'               => __( 'Sanitize SVG (inspect only)', 'thisismyurl-svg-support' ),
+				'description'         => __( 'Runs SVG markup through the allowlist sanitizer (enshrined/svg-sanitize) and returns the cleaned result for inspection — without writing anything to disk. Pass either raw SVG markup or the ID of an existing SVG attachment (exactly one). Use this to preview what sanitization would strip before trusting or storing an SVG.', 'thisismyurl-svg-support' ),
+				'category'            => 'site',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'markup'        => array(
+							'type'        => 'string',
+							'description' => __( 'Raw SVG markup to sanitize. Provide this OR attachment_id, not both.', 'thisismyurl-svg-support' ),
+						),
+						'attachment_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'ID of an existing SVG attachment to read and sanitize a copy of. Provide this OR markup, not both. The file on disk is never modified.', 'thisismyurl-svg-support' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'required'             => array( 'sanitized', 'was_modified', 'issues' ),
+					'properties'           => array(
+						'sanitized'    => array(
+							'type'        => 'string',
+							'description' => __( 'The sanitized SVG markup.', 'thisismyurl-svg-support' ),
+						),
+						'was_modified' => array(
+							'type'        => 'boolean',
+							'description' => __( 'True if the sanitizer changed the input; false if the input was already clean.', 'thisismyurl-svg-support' ),
+						),
+						'issues'       => array(
+							'type'        => 'array',
+							'description' => __( 'Report of items the sanitizer flagged or removed (XML parse warnings and cleaned elements/attributes), as exposed by the underlying library.', 'thisismyurl-svg-support' ),
+							'items'       => array(
+								'type' => 'object',
+							),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => 'timu_svg_ability_sanitize',
+				'permission_callback' => 'timu_svg_ability_can_sanitize',
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+);
+
+if ( ! function_exists( 'timu_svg_ability_can_sanitize' ) ) {
+	/**
+	 * Permission gate for the sanitize-svg ability.
+	 *
+	 * Matches the capability this plugin gates SVG handling on
+	 * ({@see TIMU_SVG_Support::UPLOAD_CAP}, `upload_svg_files`). When an
+	 * attachment is targeted, the user must additionally be able to read that
+	 * specific attachment.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return bool|WP_Error True if allowed, WP_Error otherwise.
+	 */
+	function timu_svg_ability_can_sanitize( $input = array() ) {
+		$cap = class_exists( 'TIMU_SVG_Support' ) ? TIMU_SVG_Support::UPLOAD_CAP : 'upload_files';
+		if ( ! current_user_can( $cap ) ) {
+			return new WP_Error(
+				'timu_svg_forbidden',
+				__( 'You are not allowed to sanitize SVG content.', 'thisismyurl-svg-support' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$input = is_array( $input ) ? $input : array();
+		if ( isset( $input['attachment_id'] ) ) {
+			$attachment_id = absint( $input['attachment_id'] );
+			if ( $attachment_id > 0 && ! current_user_can( 'read_post', $attachment_id ) ) {
+				return new WP_Error(
+					'timu_svg_forbidden_attachment',
+					__( 'You are not allowed to read that attachment.', 'thisismyurl-svg-support' ),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'timu_svg_ability_sanitize' ) ) {
+	/**
+	 * Execute the sanitize-svg ability.
+	 *
+	 * Wraps {@see TIMU_SVG_Sanitizer::sanitize_string()} — the plugin's pure
+	 * in-memory sanitizer — and reports issues via
+	 * {@see TIMU_SVG_Sanitizer::get_last_issues()}. The attachment path reads
+	 * the stored file into memory and sanitizes the copy; the stored file is
+	 * never touched.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>|WP_Error Structured result or error.
+	 */
+	function timu_svg_ability_sanitize( $input = array() ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$has_markup     = isset( $input['markup'] ) && '' !== trim( (string) $input['markup'] );
+		$has_attachment = isset( $input['attachment_id'] ) && absint( $input['attachment_id'] ) > 0;
+
+		if ( $has_markup === $has_attachment ) {
+			return new WP_Error(
+				'timu_svg_invalid_input',
+				__( 'Provide exactly one of "markup" or "attachment_id".', 'thisismyurl-svg-support' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( $has_attachment ) {
+			$raw = timu_svg_ability_read_attachment_svg( absint( $input['attachment_id'] ) );
+			if ( is_wp_error( $raw ) ) {
+				return $raw;
+			}
+		} else {
+			$raw = (string) $input['markup'];
+		}
+
+		if ( ! class_exists( 'TIMU_SVG_Sanitizer' ) ) {
+			return new WP_Error(
+				'timu_svg_sanitizer_unavailable',
+				__( 'The SVG sanitizer is unavailable.', 'thisismyurl-svg-support' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$sanitized = TIMU_SVG_Sanitizer::sanitize_string( $raw );
+		if ( false === $sanitized ) {
+			return new WP_Error(
+				'timu_svg_sanitize_failed',
+				/* translators: %s: short failure code from the sanitizer. */
+				sprintf( __( 'Sanitization failed: %s', 'thisismyurl-svg-support' ), TIMU_SVG_Sanitizer::get_last_error() ),
+				array( 'status' => 422 )
+			);
+		}
+
+		return array(
+			'sanitized'    => $sanitized,
+			'was_modified' => $sanitized !== $raw,
+			'issues'       => array_values( TIMU_SVG_Sanitizer::get_last_issues() ),
+		);
+	}
+}
+
+if ( ! function_exists( 'timu_svg_ability_read_attachment_svg' ) ) {
+	/**
+	 * Read an SVG attachment's raw markup into memory, decoding .svgz transparently.
+	 *
+	 * Read-only: the stored file is never modified.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return string|WP_Error Raw SVG markup, or error if not a readable SVG.
+	 */
+	function timu_svg_ability_read_attachment_svg( int $attachment_id ) {
+		$post = get_post( $attachment_id );
+		if ( ! $post || 'attachment' !== $post->post_type ) {
+			return new WP_Error(
+				'timu_svg_not_found',
+				__( 'Attachment not found.', 'thisismyurl-svg-support' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'image/svg+xml' !== get_post_mime_type( $attachment_id ) ) {
+			return new WP_Error(
+				'timu_svg_not_svg',
+				__( 'That attachment is not an SVG.', 'thisismyurl-svg-support' ),
+				array( 'status' => 415 )
+			);
+		}
+
+		$path = get_attached_file( $attachment_id );
+		if ( ! $path || ! is_readable( $path ) ) {
+			return new WP_Error(
+				'timu_svg_unreadable',
+				__( 'The SVG file could not be read.', 'thisismyurl-svg-support' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local attachment path on disk, not a remote URL.
+		if ( false === $contents || '' === $contents ) {
+			return new WP_Error(
+				'timu_svg_empty',
+				__( 'The SVG file is empty or unreadable.', 'thisismyurl-svg-support' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		// Transparently decode .svgz (gzip) so callers can inspect the markup.
+		if ( 0 === strncmp( $contents, "\x1f\x8b\x08", 3 ) && function_exists( 'gzdecode' ) ) {
+			$decoded = gzdecode( $contents );
+			if ( false !== $decoded ) {
+				$contents = $decoded;
+			}
+		}
+
+		return $contents;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Plugin URI: https://thisismyurl.com/thisismyurl-svg-support/
 Author: This Is My URL
 Author URI: https://thisismyurl.com/
 
-Safe SVG uploads for WordPress with allowlist sanitization (enshrined/svg-sanitize), MIME validation, per-role permissions, and a sandboxed admin preview.
+Safe SVG uploads for WordPress with allowlist sanitization (enshrined/svg-sanitize), MIME validation, and per-role permissions.
 
 == Description ==
 
@@ -24,7 +24,6 @@ SVG Support enables secure SVG upload workflows in WordPress with hardened defau
 * Allowlist sanitization via the well-vetted [enshrined/svg-sanitize](https://github.com/darylldoyle/svg-sanitizer) library
 * Server-side MIME validation with `finfo_file()` before sanitization runs
 * Per-role upload allowlist configurable from Settings > SVG Support
-* Sandboxed iframe preview in the Media Library (no cookie/JS exfil surface)
 * Sanitization-failure log (last 50 events) for incident response
 
 = Practical benefits =
@@ -64,6 +63,9 @@ It lives in the `timu_svg_failure_log` option. Inspect it with WP-CLI:
 `wp option get timu_svg_failure_log --format=json`
 
 == Changelog ==
+
+= 1.6149 =
+* **Security/honesty:** Removed the "sandboxed iframe preview" claim from the readme and settings page, and deleted the dead `sandbox_svg_preview()` code path that set an `svg_sandbox_html` key nothing consumed. The preview was never wired (the plugin ships no Media-view JS to render it), so SVGs still rendered as raw `<img>`. The real defense — allowlist sanitization on upload plus `finfo_file()` MIME validation — is unchanged and remains the control. Shipped state now matches the documentation.
 
 = 1.6148 =
 * **Feature:** WordPress 7.0 Abilities API support. Registers the readonly `thisismyurl-svg-support/sanitize-svg` ability, which sanitizes SVG markup (or an existing SVG attachment, read-only) in memory and returns the cleaned result plus a report of what was stripped — without modifying any stored file.

--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,9 @@ It lives in the `timu_svg_failure_log` option. Inspect it with WP-CLI:
 
 == Changelog ==
 
+= 1.6148 =
+* **Feature:** WordPress 7.0 Abilities API support. Registers the readonly `thisismyurl-svg-support/sanitize-svg` ability, which sanitizes SVG markup (or an existing SVG attachment, read-only) in memory and returns the cleaned result plus a report of what was stripped — without modifying any stored file.
+
 = 1.6147 =
 * Unified plugin versioning to the x.Yddd calendar-version scheme.
 * Confirmed compatibility with WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: svg, media library, sanitization, uploads, security
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 1.6147
+Stable tag: 1.6148.2110
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://thisismyurl.com/thisismyurl-svg-support/

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ It lives in the `timu_svg_failure_log` option. Inspect it with WP-CLI:
 = 0.6123 =
 * **Security:** Replaced the self-rolled denylist sanitizer with the allowlist-based `enshrined/svg-sanitize` library. Addresses GHSA-wmc2-4458-vm72.
 * **Security:** Added `finfo_file()` server-side MIME validation before sanitization.
-* **Security:** Sandboxed Media Library SVG preview in `<iframe sandbox="">`.
+* **Security:** Sandboxed Media Library SVG preview in `<iframe sandbox="">` (never functioned; removed in 1.6149).
 * **Feature:** Per-role upload allowlist with a new `upload_svg_files` capability.
 * **Feature:** Sanitization-failure log (last 50 events) at `timu_svg_failure_log`.
 * **Fix:** Settings page moved to `Settings > SVG Support` to match documentation.

--- a/thisismyurl-svg-support.php
+++ b/thisismyurl-svg-support.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       This Is My URL - SVG Support
  * Plugin URI:        https://thisismyurl.com/thisismyurl-svg-support/
- * Description:       Safely enable SVG uploads in the WordPress Media Library with allowlist sanitization, MIME validation, per-role permissions, and a sandboxed admin preview.
+ * Description:       Safely enable SVG uploads in the WordPress Media Library with allowlist sanitization, MIME validation, and per-role permissions.
  * Version:           1.6147
  * Requires at least: 6.0
  * Requires PHP:      8.1
@@ -56,7 +56,6 @@ class TIMU_SVG_Support {
 		add_action( 'admin_head', array( $this, 'fix_svg_media_library_display' ) );
 		add_action( 'admin_init', array( $this, 'register_svg_settings' ) );
 		add_action( 'admin_menu', array( $this, 'create_svg_settings_page' ) );
-		add_filter( 'wp_prepare_attachment_for_js', array( $this, 'sandbox_svg_preview' ), 10, 2 );
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_action_links' ) );
 	}
 
@@ -247,6 +246,8 @@ class TIMU_SVG_Support {
 	 * @return array
 	 */
 	public function add_svg_mime_types( $mimes ) {
+		// Registers the MIME only — the per-role allowlist gate (UPLOAD_CAP) is
+		// enforced in sanitize_svg_on_upload() on wp_handle_upload_prefilter.
 		$options    = (array) get_option( self::OPTION_KEY, array() );
 		$is_enabled = isset( $options['enabled'] ) && 1 === (int) $options['enabled'];
 
@@ -413,7 +414,7 @@ class TIMU_SVG_Support {
 						<div class="postbox">
 							<h2 class="hndle"><span><?php esc_html_e( 'Documentation', 'thisismyurl-svg-support' ); ?></span></h2>
 							<div class="inside">
-								<p><?php esc_html_e( 'SVG files are XML-based and can carry executable content. Uploads are sanitized via an allowlist (enshrined/svg-sanitize) before being stored. Admin previews are sandboxed.', 'thisismyurl-svg-support' ); ?></p>
+								<p><?php esc_html_e( 'SVG files are XML-based and can carry executable content. Uploads are sanitized via an allowlist (enshrined/svg-sanitize) before being stored.', 'thisismyurl-svg-support' ); ?></p>
 								<hr />
 								<p>
 									<a href="<?php echo esc_url( 'https://github.com/sponsors/thisismyurl' ); ?>" class="button button-secondary" target="_blank" rel="noopener">
@@ -427,42 +428,6 @@ class TIMU_SVG_Support {
 			</div>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Sandbox SVG previews in the Media Library. We replace the rendered
-	 * `<img src="...svg">` tile with a sandboxed iframe pointing at the SVG —
-	 * cookie/JS exfil from a pre-sanitization or edge-case payload is contained.
-	 *
-	 * @param array   $response Attachment data prepared for JS.
-	 * @param WP_Post $attachment Attachment post.
-	 * @return array
-	 */
-	public function sandbox_svg_preview( $response, $attachment ) {
-		if ( empty( $response['mime'] ) || 'image/svg+xml' !== $response['mime'] ) {
-			return $response;
-		}
-
-		$src = wp_get_attachment_url( $attachment->ID );
-		if ( ! $src ) {
-			return $response;
-		}
-
-		// Replace inline-img preview surfaces with a sandboxed iframe markup
-		// that the Media modal will render as the rich content area. The
-		// `sandbox` attribute is empty -> all powerful features denied.
-		$iframe = sprintf(
-			'<iframe src="%s" sandbox="" referrerpolicy="no-referrer" loading="lazy" style="width:100%%;height:100%%;min-height:240px;border:0;background:#fff;" title="%s"></iframe>',
-			esc_url( $src ),
-			esc_attr__( 'Sanitized SVG preview', 'thisismyurl-svg-support' )
-		);
-
-		$response['image']['src'] = $src;
-		// Modal "rich" preview uses `sizes` / `image` keys; provide an HTML
-		// override the modal's view will surface.
-		$response['svg_sandbox_html'] = $iframe;
-
-		return $response;
 	}
 }
 

--- a/thisismyurl-svg-support.php
+++ b/thisismyurl-svg-support.php
@@ -25,6 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/class-svg-sanitizer.php';
+require_once __DIR__ . '/abilities.php';
 
 /**
  * Main plugin controller.

--- a/thisismyurl-svg-support.php
+++ b/thisismyurl-svg-support.php
@@ -3,7 +3,7 @@
  * Plugin Name:       This Is My URL - SVG Support
  * Plugin URI:        https://thisismyurl.com/thisismyurl-svg-support/
  * Description:       Safely enable SVG uploads in the WordPress Media Library with allowlist sanitization, MIME validation, and per-role permissions.
- * Version:           1.6147
+ * Version:           1.6148.2110
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Author:            Christopher Ross


### PR DESCRIPTION
WP 7 hardening pass — thisismyurl-svg-support.

Recommendation: **QUICK** (contained fixes — quick activation check then merge + tag).

Changes (4 commits):
- Add WP 7 Abilities API support
- Fix P1/P2 dead sandbox-preview claim + P3 changelog/comment
- Apply gate-editor readme fixes
- Stamp release version 1.6148.2110

Audit + scorecard: clients/thisismyurl/plugin-line-hardening/HARDENING-AUDIT.md
All files php -l clean. Version stamped X.6148.2110 (Toronto).